### PR TITLE
Fix dockerfile -> Adding manually missing Python dependency prior to npm install and npmrc

### DIFF
--- a/generators/app/templates/root/_Dockerfile
+++ b/generators/app/templates/root/_Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /usr/src/app
 # Install app dependencies
 COPY package*.json ./
 
+# In order to run node alpine image avoiding Python error
+RUN apk --no-cache add --virtual builds-deps build-base python
+
 RUN npm install
 
 # Bundle app source

--- a/generators/app/templates/root/_Dockerfile
+++ b/generators/app/templates/root/_Dockerfile
@@ -4,7 +4,7 @@ FROM node:10.16-alpine
 WORKDIR /usr/src/app
 
 # Install app dependencies
-COPY package*.json ./
+COPY .npmrc package*.json ./
 
 # In order to run node alpine image avoiding Python error
 RUN apk --no-cache add --virtual builds-deps build-base python


### PR DESCRIPTION
Using node-alpine, when building a docker image, we are getting an error related to some Python missing dependency, this PR fixes that.

Log with the aforementioned error when building image: 
https://drive.google.com/file/d/11kyHQ2nxtnEp-pYW1nQB0SafE9K8bGWT/view?usp=sharing


Further info -> https://github.com/nodejs/docker-node/issues/282


Also this PR adds the .npmrc file (@kevinccbsg )