### PR TITLE
refactor: change express-swagger-generator to express-jsdoc-swagger

### DIFF
--- a/generators/app/templates/config/default.js
+++ b/generators/app/templates/config/default.js
@@ -6,26 +6,27 @@ module.exports = {
 	routes: {
 		admin: {
 			swaggerOptions: {
-				swaggerDefinition: {
-					info: {
-						description: 'Documentation for <%= name %>',
-						title: '<%= name %>',
-						version: '1.0.0',
-					},
-					host: process.env.SERVICE_ENV || 'localhost:4000',
-					basePath: '/v1',
-					produces: ['application/json'],
-					schemes: ['http'],
-					securityDefinitions: {
-						JWT: {
-							type: 'apiKey',
-							in: 'header',
-							name: 'Authorization',
-							description: '',
-						},
-					},
-				},
-			},
+        info: {
+          description: 'Documentation for <%= name %>',
+          title: '<%= name %>',
+          version: '1.0.0',
+          contact: {
+            name: 'Contact name',
+            email: 'contact email',
+          },
+        },
+        servers: [],
+        security: {
+          JWT: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'Authorization',
+          },
+        },
+        baseDir: process.cwd(),
+        swaggerUIPath: '/docs/api',
+        filesPattern: './**/**-routes.js',
+      },
 		},
 	},
 	metrics: {

--- a/generators/app/templates/lib/components/routes/admin-routes.js
+++ b/generators/app/templates/lib/components/routes/admin-routes.js
@@ -1,28 +1,21 @@
-const expressSwaggerGenerator = require('express-swagger-generator');
+const expressJSDocSwagger = require('express-jsdoc-swagger');
 
 module.exports = () => {
-	const start = async ({ manifest = {}, app, config }) => {
-		const { swaggerOptions } = config;
-		const expressSwagger = expressSwaggerGenerator(app);
-		const options = {
-			swaggerDefinition: {
-				...swaggerOptions.swaggerDefinition,
-			},
-			basedir: __dirname,
-			files: ['./**/**-routes.js'],
-		};
-		expressSwagger(options);
+  const start = async ({ manifest = {}, app, config }) => {
+    const { swaggerOptions } = config;
+    const expressSwagger = expressSwaggerGenerator(app);
+    expressJSDocSwagger(app)(swaggerOptions);
 
-		/**
-		 * This endpoint serves the manifest
-		 * @route GET /__/manifest
-		 * @group Admin - Everything about admin routes
-		 * @returns 200 - Sucessful response
-		*/
-		app.get('/__/manifest', (req, res) => res.json(manifest));
+    /**
+     * GET /__/manifest
+     * @summary This endpoint serves the manifest
+     * @tags Admin - Everything about admin routes
+     * @return {object} 200 - Sucessful response
+    */
+    app.get('/__/manifest', (req, res) => res.json(manifest));
 
-		return Promise.resolve();
-	};
+    return Promise.resolve();
+  };
 
-	return { start };
+  return { start };
 };

--- a/generators/app/templates/root/_package.json
+++ b/generators/app/templates/root/_package.json
@@ -39,7 +39,7 @@
     "chalk": "^1.1.3",
     "confabulous": "^1.1.0",
     "debug": "^2.2.0",
-    "express-swagger-generator": "^1.1.15",
+    "express-jsdoc-swagger": "^1.0.3",
     "hogan.js": "^3.0.2",
     "make-manifest": "^1.0.1",
     "optimist": "^0.6.1",


### PR DESCRIPTION
### Type:
* [ ] cicd: helm, docker & cicd adjustments.
* [X] feature: new capabilities.
* [ ] fix: bug, hotfix, etc.
* [X] refactor: enhacements.
* [ ] style: changes in styles.
* [ ] other: docs, tests.

### What's the focus of this PR:
This PR changes the default swagger generator to [express-jsdoc-swagger](https://github.com/BRIKEV/express-jsdoc-swagger). If we compare both packages:

- express-jsdoc-swagger docs has full support to OpenAPI 3.x the old one only v2.
- It is well maintained [Link to codeclimate](https://codeclimate.com/github/BRIKEV/express-jsdoc-swagger)
- It has [better docs](https://brikev.github.io/express-jsdoc-swagger-docs/#/)
- It is going to be part of swagger-endpoint-validator options in the next release. https://github.com/guidesmiths/swagger-endpoint-validator/commit/2edea5507a28a697eaa7f9bcf9db2018990cb9b3

